### PR TITLE
ci: select Xcode by version and run CI on the xcode-27 image

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,8 +25,14 @@ jobs:
           docker run --rm -v "$PWD:/code" ghcr.io/realm/swiftlint:latest lint --quiet --strict
 
   build-and-test:
-    # Requires macOS 27 (Golden Gate) — Xcode 27+. Builds against the macOS 15 deployment target.
-    runs-on: [self-hosted, macOS, ARM64]
+    # Needs Xcode 27+ for the Swift 6.4 toolchain and the macOS 27 SDK.
+    # The deployment target is macOS 15 and the macOS 27 APIs are weakly
+    # linked, so the host does not have to run macOS 27 — GitHub's xcode-27
+    # image (macOS 26) qualifies. See scripts/select-xcode.sh.
+    #
+    # That image is a public preview, so expect queueing and the occasional
+    # flake (actions/runner-images#14404). Swap to macos-27 once it exists.
+    runs-on: xcode-27
 
     steps:
       - uses: actions/checkout@v7
@@ -38,19 +44,10 @@ jobs:
           key: spm-${{ runner.os }}-${{ hashFiles('Package.resolved') }}
           restore-keys: spm-${{ runner.os }}-
 
-      - name: Select Xcode 27
+      - name: Select Xcode 27+
         run: |
-          for dir in \
-            /Applications/Xcode-beta.app/Contents/Developer \
-            /Applications/Xcode_27*.app/Contents/Developer; do
-            if [ -d "$dir" ] && [ -x "$dir/usr/bin/xcodebuild" ]; then
-              echo "DEVELOPER_DIR=$dir" >> "$GITHUB_ENV"
-              echo "$($dir/usr/bin/xcodebuild -version | head -1)"
-              exit 0
-            fi
-          done
-          echo "Error: Xcode 27 not found" >&2
-          exit 1
+          DEVELOPER_DIR="$(scripts/select-xcode.sh)"
+          echo "DEVELOPER_DIR=$DEVELOPER_DIR" >> "$GITHUB_ENV"
 
       - name: Build
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,6 +9,10 @@ permissions:
 
 jobs:
   release:
+    # Needs Xcode 27+ — see scripts/select-xcode.sh. Deliberately self-hosted
+    # rather than GitHub's xcode-27 image: signing needs the Developer ID
+    # certificate and notary credentials already in the keychain, and the
+    # shortcut in "Ensure Developer ID certificate" assumes a persistent runner.
     runs-on: [self-hosted, macOS, ARM64]
     env:
       HAS_DEV_CERT: ${{ secrets.DEVELOPER_ID_CERT || '' }}
@@ -16,19 +20,10 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
-      - name: Select Xcode 27
+      - name: Select Xcode 27+
         run: |
-          for dir in \
-            /Applications/Xcode-beta.app/Contents/Developer \
-            /Applications/Xcode_27*.app/Contents/Developer; do
-            if [ -d "$dir" ] && [ -x "$dir/usr/bin/xcodebuild" ]; then
-              echo "DEVELOPER_DIR=$dir" >> "$GITHUB_ENV"
-              echo "$($dir/usr/bin/xcodebuild -version | head -1)"
-              exit 0
-            fi
-          done
-          echo "Error: Xcode 27 not found" >&2
-          exit 1
+          DEVELOPER_DIR="$(scripts/select-xcode.sh)"
+          echo "DEVELOPER_DIR=$DEVELOPER_DIR" >> "$GITHUB_ENV"
 
       - name: Update version
         run: |

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,6 +12,14 @@ Home Assistant OS on Apple Silicon using the native Virtualization framework.
 - **Swift 6.4** (included with Xcode)
 - A **GitHub account** for submitting pull requests
 
+If you have more than one Xcode installed, `scripts/select-xcode.sh` picks the
+newest that satisfies the minimum (stable releases before betas) — the same
+script CI runs:
+
+```bash
+export DEVELOPER_DIR="$(scripts/select-xcode.sh)"
+```
+
 ### Clone and Build
 
 ```bash

--- a/docs/building.md
+++ b/docs/building.md
@@ -23,6 +23,16 @@ title: Building from Source
 - Xcode 27+ (for the toolchain and provisioning profile)
 - Swift 6.4
 
+The released Xcode 27 installs to `/Applications/Xcode.app`. If you keep
+several Xcodes around, `scripts/select-xcode.sh` picks the newest one that
+satisfies the minimum (stable releases before betas):
+
+```bash
+export DEVELOPER_DIR="$(scripts/select-xcode.sh)"
+```
+
+CI uses the same script, so builds and releases always agree on the toolchain.
+
 ## Quick Build
 
 ```bash

--- a/scripts/publish.sh
+++ b/scripts/publish.sh
@@ -56,6 +56,13 @@ if ! gh auth status &>/dev/null; then
     exit 1
 fi
 
+# --- Toolchain ---------------------------------------------------------------
+# Same selection the release workflow uses. The default Xcode is not
+# necessarily the newest installed one, and we need 27+.
+echo "==> Selecting Xcode toolchain..."
+DEVELOPER_DIR="$(./scripts/select-xcode.sh)"
+export DEVELOPER_DIR
+
 # --- Build -------------------------------------------------------------------
 echo "==> Building havm v${VERSION} (tier 3, Developer ID)..."
 

--- a/scripts/select-xcode.sh
+++ b/scripts/select-xcode.sh
@@ -1,0 +1,128 @@
+#!/bin/bash
+#
+# Pick an Xcode toolchain for building havm.
+#
+# havm needs Xcode 27 or later (Swift 6.4 toolchain, macOS 27 SDK) while still
+# deploying to macOS 15. Xcode 27 has shipped, so it normally sits at the
+# default /Applications/Xcode.app — but runners and dev machines often carry
+# several installs, and the default location is not guaranteed to be the
+# newest. Select by the version each bundle reports, never by filename.
+#
+# Precedence:
+#   1. $DEVELOPER_DIR, if it satisfies the minimum (used verbatim)
+#   2. newest stable install (Xcode.app, Xcode_*.app, the active xcode-select)
+#   3. newest beta install — only if no stable install qualifies
+#
+# Candidates are resolved through symlinks before they are compared, because
+# /Applications/Xcode.app is a symlink to the *default* install on GitHub's
+# images — which is not necessarily the newest one.
+#
+# Prints the Developer directory on stdout; progress goes to stderr, so it
+# composes:
+#   export DEVELOPER_DIR="$(scripts/select-xcode.sh)"
+
+set -euo pipefail
+
+MIN_MAJOR="${MIN_XCODE_MAJOR:-27}"
+
+# Version reported by an .app bundle, or empty if it can't be run.
+xcode_version() {
+    local app="$1" out
+    [ -x "$app/Contents/Developer/usr/bin/xcodebuild" ] || return 0
+    out=$("$app/Contents/Developer/usr/bin/xcodebuild" -version 2>/dev/null | head -1) || true
+    printf '%s' "${out##* }"
+}
+
+# Version of an .app bundle if it satisfies the minimum, otherwise nothing.
+supported_version() {
+    local version major
+    version=$(xcode_version "$1")
+    [ -n "$version" ] || return 0
+    major="${version%%.*}"
+    case "$major" in
+        ''|*[!0-9]*) return 0 ;;
+    esac
+    if [ "$major" -ge "$MIN_MAJOR" ]; then
+        printf '%s' "$version"
+    fi
+}
+
+# Echo the newest supported .app among the arguments.
+newest_supported() {
+    local app version best="" best_version=""
+    for app in "$@"; do
+        version=$(supported_version "$app")
+        if [ -z "$version" ]; then
+            echo "    skipping $app (not Xcode $MIN_MAJOR+)" >&2
+            continue
+        fi
+        if [ -z "$best_version" ] ||
+            [ "$(printf '%s\n%s\n' "$best_version" "$version" | sort -V | tail -1)" = "$version" ]; then
+            best="$app"
+            best_version="$version"
+        fi
+    done
+    if [ -n "$best" ]; then
+        printf '%s' "$best"
+    fi
+}
+
+# 1. An explicitly set DEVELOPER_DIR wins, as long as it satisfies the minimum.
+if [ -n "${DEVELOPER_DIR:-}" ]; then
+    app="${DEVELOPER_DIR%/Contents/Developer}"
+    version=$(supported_version "$app")
+    if [ -n "$version" ]; then
+        echo "    using \$DEVELOPER_DIR (Xcode $version)" >&2
+        printf '%s\n' "$app/Contents/Developer"
+        exit 0
+    fi
+    echo "    ignoring \$DEVELOPER_DIR=$DEVELOPER_DIR (not Xcode $MIN_MAJOR+)" >&2
+fi
+
+# 2. Collect installs, keeping betas aside as a fallback. The active
+#    xcode-select path usually duplicates one of the /Applications globs.
+stable=()
+beta=()
+seen=$'\n'
+
+add_candidate() {
+    local app="$1" real
+    [ -n "$app" ] && [ -d "$app" ] || return 0
+    # Resolve symlinks. GitHub's images alias several names onto one bundle
+    # (/Applications/Xcode.app and /Applications/Xcode_<v>.app both point at
+    # Xcode_<v>.app), and a beta must be classified by its real name rather
+    # than whichever alias reached it.
+    real=$(cd "$app" && pwd -P) || return 0
+    case "$seen" in
+        *$'\n'"$real"$'\n'*) return 0 ;;
+    esac
+    seen="$seen$real"$'\n'
+    case "${real##*/}" in
+        *[Bb]eta*) beta+=("$real") ;;
+        *)         stable+=("$real") ;;
+    esac
+}
+
+active=$(xcode-select -p 2>/dev/null) || active=""
+add_candidate "${active%/Contents/Developer}"
+for app in /Applications/Xcode.app /Applications/Xcode_*.app /Applications/Xcode-beta.app; do
+    add_candidate "$app"
+done
+
+picked=""
+if [ "${#stable[@]}" -gt 0 ]; then
+    picked=$(newest_supported "${stable[@]}")
+fi
+if [ -z "$picked" ] && [ "${#beta[@]}" -gt 0 ]; then
+    echo "    no stable Xcode $MIN_MAJOR+ installed, falling back to beta" >&2
+    picked=$(newest_supported "${beta[@]}")
+fi
+
+if [ -z "$picked" ]; then
+    echo "Error: no Xcode $MIN_MAJOR or later found." >&2
+    echo "Install Xcode $MIN_MAJOR from the App Store, or point \$DEVELOPER_DIR at one." >&2
+    exit 1
+fi
+
+echo "    using $picked (Xcode $(xcode_version "$picked"))" >&2
+printf '%s\n' "$picked/Contents/Developer"


### PR DESCRIPTION
Xcode 27 now installs to the default `/Applications/Xcode.app`, which the workflows' name-based probe (`Xcode-beta.app`, `Xcode_27*.app`) doesn't match — so the toolchain step failed on any machine with only the released Xcode.

## Changes

**`scripts/select-xcode.sh`** (new) picks a toolchain by the version each bundle reports, not by filename:

1. `$DEVELOPER_DIR`, if it satisfies the minimum (used verbatim)
2. newest stable install (`Xcode.app`, `Xcode_*.app`, the active `xcode-select`)
3. newest beta — only if no stable install qualifies

Candidates are resolved through symlinks before comparison, because images alias several names onto one bundle. `/Applications/Xcode.app` is a symlink to the *default*, which is not necessarily the newest — on `macos-15-arm64` it points at 16.4 while 26.3 is installed. And on the `xcode-27` image the real bundle is `Xcode_27_beta_6.app`, so classifying betas by the alias that reached them would have let a beta outrank a stable install.

Prints only the Developer dir on stdout so it composes: `export DEVELOPER_DIR="$(scripts/select-xcode.sh)"`. Minimum overridable via `MIN_XCODE_MAJOR`. Written for macOS's system bash 3.2.

**Workflows** — both jobs now call the script and export `DEVELOPER_DIR` via `$GITHUB_ENV`. `scripts/publish.sh` selects the same toolchain, so local and CI releases agree. Documented in `CONTRIBUTING.md` and `docs/building.md`.

**`build-and-test` moves to `runs-on: xcode-27`** — GitHub's macOS 26 + Xcode 27 public preview (actions/runner-images#14404). The build needs Xcode 27's macOS 27 SDK rather than a macOS 27 host: `Package.swift` targets `.macOS(.v15)` and the macOS 27 APIs are `@_weakLinked` + `@available(macOS 27.0, *)`. `release` stays self-hosted, where signing credentials already sit in the keychain.

## Testing

- Simulated image layouts: replica of `xcode-27` (only an aliased beta 27) → beta fallback resolving to the real bundle; same plus a stable 27.1 → 27.1 wins; replica of `macos-15` → correct failure
- Multi-install case: 26.4 default + 27.0 + 27.2 + beta 28.0 → picks 27.2 (stable beats a newer beta)
- `$DEVELOPER_DIR` override honored; a bogus one is ignored and the search continues
- `shellcheck scripts/*.sh` clean; both workflows parse
- Full CI path locally (`DEVELOPER_DIR` + `ENTITLEMENTS_TIER=1 CODE_SIGN_IDENTITY="-" ./scripts/build.sh release`): builds, prints `havm 0.3.1`; `swift test` → 29 tests pass

**Unverified:** `swift test` executing on a macOS 26 host. Availability is checked against the deployment target, not the host, and neither test file references `#available`, `ProcessInfo.operatingSystemVersion`, or the gated USB code — but this run is the real test of it. `xcode-27` is a preview label, so queueing may be slow.